### PR TITLE
Make the exporter more restricted

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,22 @@ $ curl localhost:9117/metrics
 
 **(Optional)** If the `system-files` interface is not connected automatically,
 you can connect the `system-files` interface manually, this will allow the snap
-to have read access to some directories in your host's `/etc`, which is needed
-for the exporter to read your certificates:
+to have read access to some directories in your host's `/etc` (`/etc/ovn` and
+`/etc/neutron` in particular), which is needed for the exporter to read your
+certificates:
 
 ```bash
-$ snap connect node-cert-exporter:etc
+$ snap connect node-cert-exporter:etc-ovn
+$ snap connect node-cert-exporter:etc-neutron
 ```
 
 ## Snap Configuration
+
+By default, the snap will read and expose the expiration information of the
+certificates reside in `/etc/ovn` and `/etc/neutron` with the extension of
+[".pem", ".crt", ".cert", ".cer", ".pfx"] to Prometheus as metrics. However, you
+can still fine-tune what certificates (within `/etc/ovn` and `/etc/neutron`) to
+be included of the exporter via the snap configuration.
 
 You can get a list of supported snap configuration via
 
@@ -35,19 +43,19 @@ $ snap get node-cert-exporter
 ```
 
 You can change the default configuration by running `snap set node-cert-exporter
-<key>=<value>`. For example, you can change the `exclude-glob` option to
-skip all the certificates file under `/etc/ssl/certs/`.
+<key>=<value>`. For example, you can include the certificates without the
+appropriate extensions:
 
 ```bash
-$ snap set node-cert-exporter exclude-glob="/etc/ssl/certs/*"
+$ snap set node-cert-exporter include-glob="/etc/ovn/cert_host"
 ```
 
 You can also revert to the default vaule by running `snap unset
-node-cert-exporter <key>`. For example, you can revert the `exclude-glob`
+node-cert-exporter <key>`. For example, you can revert the `include-glob`
 option.
 
 ```bash
-$ snap unset node-cert-exporter exclude-glob
+$ snap unset node-cert-exporter include-glob
 ```
 
 ## Local Build and Testing

--- a/scripts/node-cert-exporter.wrapper
+++ b/scripts/node-cert-exporter.wrapper
@@ -6,10 +6,7 @@
 # Start the exporter with config options
 exec "${SNAP}/bin/node-cert-exporter" \
     $(safe_add_option listen) \
-    $(safe_add_option path) \
-    $(safe_add_option exclude-path) \
     $(safe_add_option include-glob) \
     $(safe_add_option exclude-glob) \
-    $(safe_add_option tls) \
-    $(safe_add_option tls-cert-file) \
-    $(safe_add_option tls-key-file)
+    $(safe_add_option exclude-path) \
+    --path "/etc/ovn,/etc/neutron"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -5,13 +5,9 @@
 
 # Set snap config options
 set_default listen ":9117"
-set_default path "/etc"
-set_default exclude-path ""
 set_default include-glob ""
 set_default exclude-glob ""
-set_default tls "false"
-set_default tls-cert-file ""
-set_default tls-key-file ""
+set_default exclude-path ""
 
 # Restart snap to apply new config.
 snapctl restart $SNAP_NAME

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,10 +5,7 @@ summary: Node Cert Exporter
 description: |
   Node Cert Exporter (node-cert-exporter) is an exporter that exposes
   certificate expiration information for use by the Prometheus monitoring
-  system. By default, it will read and expose the expiration information of the
-  certificates reside in `/etc/ovn`, `/etc/neutron`, and `/etc/ssl/certs` to
-  Prometheus as metrics. However, you can still fine tune the behaviour of the
-  exporter via the snap configuration.
+  system.
 grade: stable
 confinement: strict
 
@@ -18,7 +15,8 @@ apps:
     restart-condition: on-abnormal
     command: "bin/node-cert-exporter.wrapper"
     plugs:
-      - etc
+      - etc-ovn
+      - etc-neutron
 
 parts:
   node-cert-exporter:
@@ -35,9 +33,11 @@ parts:
       node-cert-exporter.wrapper: "bin/node-cert-exporter.wrapper"
 
 plugs:
-  etc:
+  etc-ovn:
     interface: system-files
     read:
     - /etc/ovn
+  etc-neutron:
+    interface: system-files
+    read:
     - /etc/neutron
-    - /etc/ssl/certs


### PR DESCRIPTION
This PR proposed changing the exporter snap to be more restricted and targeted to openstack charmers (OVN / Neutron).

Closes: #2 