### PR TITLE
Add missing network-bind plug

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -46,7 +46,7 @@ jobs:
               exit 1
           fi
 
-          curl localhost:9117/metrics -s > /dev/null
+          curl --retry 4 --retry-connrefused localhost:9117/metrics -s > /dev/null
           status=$?
           if [ $status -ne 0 ]; then
               echo "Failed to reach the exporter!"

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 
 install: build
 	@echo "Installing the snap"
-	@snap install --devmode ${SNAP_FILE}
+	@snap install --dangerous ${SNAP_FILE}
 
 uninstall:
 	@echo "Uninstalling the snap"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ apps:
     plugs:
       - etc-ovn
       - etc-neutron
+      - network-bind
 
 parts:
   node-cert-exporter:


### PR DESCRIPTION
A `network-bind` plug is required for the snap to run as a HTTP server. [0]

[0] https://snapcraft.io/docs/network-bind-interface

Closes: #4 